### PR TITLE
Echo framework name, exit with return code.

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-echo 0
+echo "xmlsec1"
+exit 0


### PR DESCRIPTION
This PR fixes the detect script to echo the "framework name" (just a string) and exit with return code 0.
